### PR TITLE
fix: close multipart source file after copying, not before

### DIFF
--- a/client.go
+++ b/client.go
@@ -552,10 +552,7 @@ func addFile(w *multipart.Writer, fieldName, path string) error {
 	if err != nil {
 		return err
 	}
-	err = file.Close()
-	if err != nil {
-		return err
-	}
+	defer file.Close()
 
 	part, err := w.CreateFormFile(fieldName, filepath.Base(path))
 	if err != nil {

--- a/utils_test.go
+++ b/utils_test.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"testing"
 )
-
 // Regression test: addFile must close the source file only after copying its
 // contents into the multipart writer.
 func TestAddFileCopiesContentBeforeClose(t *testing.T) {
@@ -29,7 +28,7 @@ func TestAddFileCopiesContentBeforeClose(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	req, err := http.NewRequest(http.MethodPost, "http://example.invalid", &body)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, "http://example.invalid", &body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -41,7 +40,7 @@ func TestAddFileCopiesContentBeforeClose(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 	if header.Filename != "upload.txt" {
 		t.Fatalf("unexpected filename: %q", header.Filename)
 	}

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,55 @@
+package client
+
+import (
+	"bytes"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Regression test: addFile must close the source file only after copying its
+// contents into the multipart writer.
+func TestAddFileCopiesContentBeforeClose(t *testing.T) {
+	want := "ory-file-content"
+	dir := t.TempDir()
+	path := filepath.Join(dir, "upload.txt")
+	if err := os.WriteFile(path, []byte(want), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var body bytes.Buffer
+	w := multipart.NewWriter(&body)
+	if err := addFile(w, "file", path); err != nil {
+		t.Fatalf("addFile returned error: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, "http://example.invalid", &body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	if err := req.ParseMultipartForm(1 << 20); err != nil {
+		t.Fatal(err)
+	}
+	file, header, err := req.FormFile("file")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	if header.Filename != "upload.txt" {
+		t.Fatalf("unexpected filename: %q", header.Filename)
+	}
+	got, err := io.ReadAll(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != want {
+		t.Fatalf("copied content mismatch: got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Fixes #12

## Root cause
`addFile` in `client.go` closed the source file (`file.Close()`) **before** calling `io.Copy(part, file)`, so every multipart form-file upload prepared through this helper failed with `read <file>: file already closed`.

## Change
Close the file with `defer` after the copy — smallest correct diff, matching upstream openapi-generator's Go template behavior.

## Repro
```go
var body bytes.Buffer
w := multipart.NewWriter(&body)
err := addFile(w, "file", tmpfile) // returns "read <tmpfile>: file already closed" on master
```

## Test evidence
Added `utils_test.go` (`TestAddFileCopiesContentBeforeClose`), which builds a multipart body via `addFile` and asserts the file contents round-trip:

- On this PR: `go test -run TestAddFileCopiesContentBeforeClose .` → **PASS**
- On master (pre-fix): same test → **FAIL** with `addFile returned error: read ...: file already closed`

`go build ./...` passes (Go 1.26.5, module go 1.25.0).

Signed-off-by: Tyagiquamar <Tyagiquamar@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file handling during multipart uploads so file contents are fully copied before the source file is closed, helping preserve uploaded data reliably.

* **Tests**
  * Added regression coverage confirming that multipart uploads retain the original filenames and file contents after processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->